### PR TITLE
use proper SPDX license code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "author": "Leap DAO",
-  "license": "AGPLv3",
+  "license": "AGPL-3.0-or-later",
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",


### PR DESCRIPTION
This removes "License should be a valid SPDX license expression" npm warning