### PR TITLE
[💥breaking] fix: make getUnspent require 2 params (address and color)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -24,7 +24,7 @@ export function extendWeb3(web3Instance) {
   const getUnspent = {
     name: 'getUnspent',
     call: 'plasma_unspent',
-    params: 1,
+    params: 2,
     inputFormatters: [
       extend.formatters.inputAddressFormatter, // account address
     ],


### PR DESCRIPTION
`getUnspent` JSON RPC supports 2 arguments. With current implementation it is not possible (?) to specify color.

Reference: https://github.com/leapdao/leap-node/blob/master/src/api/methods/getUnspent.js#L3

This is BREAKING CHANGE, old API calls will need to be changed to provide color as well.