### PR TITLE
Replace instanceof usage with duck-typing

### DIFF
--- a/lib/outpoint.js
+++ b/lib/outpoint.js
@@ -54,12 +54,19 @@ export default class Outpoint {
   }
 
   /**
-   * Test an object to see if it is an outpoint.
+   * Test an object to see if it is an outpoint.  This check was previously
+   * done using `instanceof`. However, this lead to problems where two
+   * instances of leap-core would become incompatible, as they compared two
+   * different instantiations of `Outpoints` with each other. We're now
+   * resorting to duck-typing instead.
+   *
    * @param {Object} obj
    * @returns {Boolean}
    */
   static isOutpoint(obj) {
-    return obj instanceof Outpoint;
+    // NOTE: We're checking obj.index for typeof "undefined" as it
+    // can become 0 (zero).
+    return obj && obj.hash && typeof obj.index !== "undefined";
   }
 
   /**


### PR DESCRIPTION
`Outpoint` has a function `isOutpoint`. It uses `instanceof` to check whether the parameter is an `Outpoint`. 

In `Input`'s `constructor` `isOutpoint` is used to check if the `options` are indeed an `Outpoint`.

This lead to a really hard to find bug for me in the burner wallet. Here's why:

We're inserting the leap-core web3 provider through dapperatus into the burner wallet. However, we're NOT doing transactions within dapparatus. These are done (due to the burner wallet's design 🤷‍♂️) in the burner wallet itself.
This leads us to import "leap-core" for its `helpers` in the burner wallet while our web3 object comes from dapparatus. When we want to send a transaction now, we'll get `getUnspent` from `dapparatus.web3`, while our helpers are from `burner-wallet.helpers`. Subsequently, when we insert the unspents into the helpers, we're getting `obj instanceof Outpoint === false` even though `obj` is of `instanceof Outpoint`. This is because there's now two instances of `Outpoint`. One from dapparatus and one from the burner wallet.

Of course this is more a specific issue of the burner-wallet and dapparatus. I think it's still worth considering using duck-typing instead of `instanceof`.
