### PR TITLE
Throw exception on serialization of tx with > 15 inputs

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -406,26 +406,33 @@ export default class Transaction {
   toRaw() {
     let payload;
     let inputs = [];
+    const writeLengths = (inputsLength, outputsLength) => {
+      // write ins and outs length as nibbles
+      if (inputsLength > 15) {
+        throw new Error('Too many inputs (>15)');
+      }
+      payload.writeUInt8((16 * inputsLength) + outputsLength, 1);
+    }
     if (this.type === Type.DEPOSIT) {
       payload = Buffer.alloc(6, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(16 + 1, 1);  // 1 inputs, 1 output
+      writeLengths(1, 1);
       payload.writeUInt32BE(this.options.depositId, 2);
     } else if (this.type === Type.EPOCH_LENGTH) {
       payload = Buffer.alloc(6, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(0, 1); // 0 inputs, 0 output
+      writeLengths(0, 0);
       payload.writeUInt32BE(this.options.epochLength, 2);
     } else if (this.type === Type.MIN_GAS_PRICE) {
       payload = Buffer.alloc(10, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(0, 1); // 0 inputs, 0 output
+      writeLengths(0, 0);
       const valueHex = BigInt(this.options.minGasPrice).toString(16);
       payload.write(valueHex.padStart(16, '0'), 2, 8, 'hex');
     } else if (this.type === Type.VALIDATOR_JOIN) {
       payload = Buffer.alloc(60, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(0, 1); // 0 inputs, 0 output
+      writeLengths(0, 0);
       payload.writeUInt16BE(this.options.slotId, 2);
       payload.write(this.options.tenderKey.replace('0x', ''), 4, 'hex');
       payload.writeUInt32BE(this.options.eventsCount, 36);
@@ -433,7 +440,7 @@ export default class Transaction {
     } else if (this.type === Type.VALIDATOR_LOGOUT) {
       payload = Buffer.alloc(64, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(0, 1); // 0 inputs, 0 output
+      writeLengths(0, 0);
       payload.writeUInt16BE(this.options.slotId, 2);
       payload.write(this.options.tenderKey.replace('0x', ''), 4, 'hex');
       payload.writeUInt32BE(this.options.eventsCount, 36);
@@ -442,7 +449,7 @@ export default class Transaction {
     } else if (this.type === Type.PERIOD_VOTE) {
       payload = Buffer.alloc(3, 0);
       payload.writeUInt8(this.type, 0);
-      payload.writeUInt8(16, 1); // 1 input, 0 output
+      writeLengths(1, 0);
       payload.writeUInt8(this.options.slotId, 2);
       inputs = this.inputs;
     } else if (this.type === Type.EXIT) {
@@ -452,14 +459,12 @@ export default class Transaction {
     } else if (this.type === Type.TRANSFER) {
       payload = Buffer.alloc(2, 0);
       payload.writeUInt8(this.type, 0);
-      // write ins and outs length as nibbles
-      payload.writeUInt8((16 * this.inputs.length) + this.outputs.length, 1);
+      writeLengths(this.inputs.length, this.outputs.length);
       inputs = this.inputs;
     } else if (this.type === Type.SPEND_COND) {
       payload = Buffer.alloc(2, 0);
       payload.writeUInt8(this.type, 0);
-      // write ins and outs length as nibbles
-      payload.writeUInt8((16 * this.inputs.length) + this.outputs.length, 1);
+      writeLengths(this.inputs.length, this.outputs.length);
       inputs = this.inputs;
     } else {
       payload = Buffer.alloc(1, 0);

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -189,6 +189,25 @@ describe('transactions', () => {
     assert.deepEqual(Tx.fromRaw(transfer.toRaw()), transfer);
   });
 
+  it('should throw with >15 inputs', () => {
+    const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+    const value = BigInt('99000000');
+    const color = 1337;
+
+    const transfer = Tx.transfer(
+      Array.from(
+        { length: 16 },
+        (_, i) => new Input(new Outpoint(prevTx, i))
+      ),
+      [new Output(value, ADDR, color)],
+    );
+
+    expect(() => {
+      transfer.signAll(PRIV);
+      transfer.toRaw();
+    }).throw('Too many inputs (>15)');
+  });
+
   it('should allow to create and parse transfer tx with 2 outputs.', () => {
     const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
     const value = BigInt('99000000');


### PR DESCRIPTION
It will provide better error then `"value" argument is out of bounds`