### PR TITLE
Query for inclusion of tx to market maker

### DIFF
--- a/lib/exit.js
+++ b/lib/exit.js
@@ -6,7 +6,7 @@ import Tx from './transaction';
 import Outpoint from './outpoint';
 import Output from './output';
 import Input from './input';
-import { periodBlockRange } from './helpers';
+import { periodBlockRange, sendSignedTransaction } from './helpers';
 
 
 export default class Exit {
@@ -103,9 +103,9 @@ export default class Exit {
 
     return (signer
       ? signer.signTx(spendTx)
-      : spendTx.signWeb3(rootChain)).then(signedTx => plasmaChain.eth.sendSignedTransaction(
-      signedTx.hex()
-    )).then(transferTx => {
+      : spendTx.signWeb3(rootChain)
+    ).then(signedTx => sendSignedTransaction(plasmaChain, signedTx.hex())
+    ).then(transferTx => {
       const tx = Tx.fromRaw(transferTx.raw);
       const utxoId = (new Outpoint(tx.hash(), 0)).getUtxoId();
       const sigHashBuff = Exit.sigHashBuff(utxoId, amount);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -202,3 +202,47 @@ export function getProof(plasma, tx, slotId, validatorAddr) {
     return period.proof(Tx.fromRaw(tx.raw));
   });
 }
+
+/**
+ * Sends a signed transaction to the node
+ *
+ * @param {ExtendedWeb3} plasma instance of Leap Web3
+ * @param {LeapTransaction} tx
+ * @returns {Promise<Receipt>} promise that resolves to a transaction receipt
+ */
+export function sendSignedTransaction(plasma, tx) {
+   return new Promise((resolve, reject) => {
+     plasma.currentProvider.send({
+       jsonrpc: '2.0',
+       id: 42,
+       method: 'eth_sendRawTransaction',
+       params: [tx] },
+       (err, res) => {
+         if (err) {
+           return reject(err);
+         }
+         return resolve(res);
+       })
+   }).then(async ({ result }) => {
+     let receipt;
+     let rounds = 50;
+
+     while(rounds--) {
+       // eslint-disable-next-line no-await-in-loop
+       const res = await plasma.eth.getTransaction(result)
+
+       if (res && res.blockHash) {
+         receipt = res;
+         break;
+       }
+
+       // wait ~100ms
+       setTimeout(null, 100);
+    }
+
+    if (receipt) {
+      return receipt;
+    }
+    throw new Error("Transaction not included in block after 5 secs.");
+  })
+}


### PR DESCRIPTION
I had a problem in the burner wallet with exits that were not sunDai. `fastSellAmount` would always throw `Error: Failed to subscribe to new newBlockHeaders to confirm the transaction receipts.`.

To circumvent this behavior, I'm using the base JSON-RPC call that doesn't call "newBlockHeaders".

I'm using this fix in https://github.com/leapdao/burner-wallet/pull/71