### PR TITLE
fix: rectify sendSignedTransaction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -317,6 +317,8 @@ declare module "leap-core" {
     export function getTxWithYoungestBlock(txs: LeapTransaction[]): InputTx;
     export function getYoungestInputTx(plasma: ExtendedWeb3, tx: Tx<any>): Promise<InputTx>;
     export function getProof(plasma: ExtendedWeb3, tx: LeapTransaction, slotId: number, validatorAddr: string): Promise<Proof>;
+    // Depending on plasma instance, resolves to either Web3's Transaction or Ethers' TransactionReceipt
+    export function sendSignedTransaction(plasma: ExtendedWeb3, tx: string): Promise<any>;
   }
 
   class Exit {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -272,7 +272,7 @@ export function getProof(plasma, tx, slotId, validatorAddr) {
  * Resolves to tx receipt if it is available, otherwise resolves to nothing.
  */
 const awaitForReceipt = (txHash, promise, plasma, round) => {
-  if (round >= 50) return Promise.resolve();
+  if (round >= 50) return Promise.reject('Transaction not included in block after 5 secs.');
 
   return promise.then((receipt) => {
     if (receipt && receipt.blockHash) {
@@ -320,10 +320,5 @@ const send = (plasma, txHex) => {
 export function sendSignedTransaction(plasma, txHex) {
   return send(plasma, txHex).then((resp) => {
     return awaitForReceipt(resp, Promise.resolve(), plasma, 0);
-  }).then((receipt) => {
-    if (receipt) {
-      return receipt;
-    }
-    throw new Error('Transaction not included in block after 5 secs.');
   });
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -268,45 +268,59 @@ export function getProof(plasma, tx, slotId, validatorAddr) {
 }
 
 /**
- * Sends a signed transaction to the node
- *
- * @param {ExtendedWeb3} plasma instance of Leap Web3
- * @param {LeapTransaction} tx
- * @returns {Promise<Receipt>} promise that resolves to a transaction receipt
+ * Polls the node for transaction receipt 50 times with 100 ms interval (5 seconds in total).
+ * Resolves to tx receipt if it is available, otherwise resolves to nothing.
  */
-export function sendSignedTransaction(plasma, tx) {
-  return new Promise((resolve, reject) => {
-    plasma.currentProvider.send(
-      {
-        jsonrpc: '2.0',
-        id: 42,
-        method: 'eth_sendRawTransaction',
-        params: [tx],
-      },
-      (err, res) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(res);
-      }
-    );
-  }).then(async ({ result }) => {
-    let receipt;
-    let rounds = 50;
+const awaitForReceipt = (txHash, promise, plasma, round) => {
+  if (round >= 50) return Promise.resolve();
 
-    while (rounds--) {
-      // eslint-disable-next-line no-await-in-loop
-      const res = await plasma.eth.getTransaction(result);
-
-      if (res && res.blockHash) {
-        receipt = res;
-        break;
-      }
-
-      // wait ~100ms
-      setTimeout(null, 100);
+  return promise.then((receipt) => {
+    if (receipt && receipt.blockHash) {
+      return Promise.resolve(receipt);
     }
 
+    const next = new Promise(resolve => 
+      setTimeout(() => (plasma.eth || plasma).getTransaction(txHash).then(resolve), 100)
+    );
+
+    return awaitForReceipt(txHash, next, plasma, round + 1);
+  });
+};
+
+const send = (plasma, txHex) => {
+  if (plasma.currentProvider) { // Web3
+    return new Promise((resolve, reject) => {
+      plasma.currentProvider.send(
+        {
+          jsonrpc: '2.0',
+          id: 42,
+          method: 'eth_sendRawTransaction',
+          params: [txHex],
+        },
+        (err, res) => {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(res);
+        }
+      );
+    });
+  }
+  return plasma.send('eth_sendRawTransaction', [txHex]); // Ethers.js
+};
+
+
+/**
+ * Sends a signed transaction to the node
+ *
+ * @param {ExtendedWeb3} plasma instance of Leap Web3 or JSONRPCProvider of Ethers.js
+ * @param {LeapTransaction} txHex - transaction to send
+ * @returns {Promise<Receipt>} promise that resolves to a transaction receipt
+ */
+export function sendSignedTransaction(plasma, txHex) {
+  return send(plasma, txHex).then((resp) => {
+    return awaitForReceipt(resp, Promise.resolve(), plasma, 0);
+  }).then((receipt) => {
     if (receipt) {
       return receipt;
     }


### PR DESCRIPTION
- got rid of `async/await` 
- supporting Ethers.js. Detect if provided plasma object is Web3 or JSONRPCProvider of Ethers.
- added `sendSignedTransaction` to typedefs. Without a proper return type for now — need to add Ethers.js typedefs for that
- use proper timeout-loop: the previous one did nothing for async code

Resolves #108 

Veried for Ethers here: https://github.com/leapdao/leap-guardian/pull/12
Haven't verified for Web3 yet