### PR TITLE
feat: add getUnspentByAddress RPC helper and fix typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -301,7 +301,7 @@ declare module "leap-core" {
 
   class ExtendedWeb3 extends Web3 {
     public getUnspent(address: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
-    public getUnspentByAddress(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;
     public getColors(cb?: Callback<string[]>): Promise<string[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,7 +300,8 @@ declare module "leap-core" {
   }
 
   class ExtendedWeb3 extends Web3 {
-    public getUnspent(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspentByAddress(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;
     public getColors(cb?: Callback<string[]>): Promise<string[]>;

--- a/lib/exit.js
+++ b/lib/exit.js
@@ -90,7 +90,7 @@ export default class Exit {
   }
 
   static fastSellAmount(account, amount, color, plasmaChain, rootChain, marketMakerUrl, signer) {
-    return Promise.all([plasmaChain.getUnspent(account), plasmaChain.getConfig()]).then(([unspent, nodeConfig]) => {
+    return Promise.all([plasmaChain.getUnspent(account, color), plasmaChain.getConfig()]).then(([unspent, nodeConfig]) => {
       const exitingUtxoTransfer = Tx.transferFromUtxos(
         unspent, account, nodeConfig.exitHandlerAddr, amount, color,
       );

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -50,6 +50,10 @@ export class LeapEthers {
       .then(unspent => unspent.map(fromRaw));
   }
 
+  getUnspentByAddress(...params) {
+    return this.getUnspent(params);
+  }
+
   getUnspentAll() {
     return this.provider
       .send('plasma_unspent', [])
@@ -100,6 +104,11 @@ export function extendWeb3(web3Instance) {
   extend({
     methods: [
       new extend.Method(getUnspent),
+      new extend.Method({
+        ...getUnspent,
+        name: 'getUnspentByAddress',
+        params: 1,
+      }),
       new extend.Method({
         ...getUnspent,
         name: 'getUnspentAll',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -103,11 +103,14 @@ export function extendWeb3(web3Instance) {
 
   extend({
     methods: [
-      new extend.Method(getUnspent),
       new extend.Method({
         ...getUnspent,
         name: 'getUnspentByAddress',
         params: 1,
+      }),
+      new extend.Method({
+        ...getUnspent,
+        name: 'getUnspentByAddressColor',
       }),
       new extend.Method({
         ...getUnspent,
@@ -153,6 +156,17 @@ export function extendWeb3(web3Instance) {
       }),
     ],
   });
+
+  web3Instance.getUnspent = (...params) => {
+    const last = params[params.length - 1];
+    const hasCb = typeof last === 'function';
+    if (params.length === (hasCb ? 2 : 1)) {
+      return web3Instance.getUnspentByAddress(...params);
+    }
+  
+    return web3Instance.getUnspentByAddressColor(...params);
+  };
+
   return web3Instance;
 }
 


### PR DESCRIPTION
- add a getUnspentByAddress RCP helper. After the #68, there is no helper to get unspents of all the colors for a given address.
This feature is used in Bridge UI.
- fix typedef for getUnspent
- make `getUnspent` helper to delegate to `getUnspentForAddress` or `getUnspentForAddressColor` depending on the number of parameters provided. This makes it backward compatible with pre-#68 code