### PR TITLE
fix: unwrap RPC response for web3

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -301,7 +301,7 @@ const send = (plasma, txHex) => {
           if (err) {
             return reject(err);
           }
-          return resolve(res);
+          return resolve(res.result);
         }
       );
     });


### PR DESCRIPTION
Ethers.js return unwrapped already