### PR TITLE
fix: proper Outpoint comparison

### DIFF
--- a/lib/outpoint.js
+++ b/lib/outpoint.js
@@ -76,7 +76,7 @@ export default class Outpoint {
    */
   equals(prevout) {
     assert(Outpoint.isOutpoint(prevout));
-    return this.hash === prevout.hash
+    return this.hash.equals(prevout.hash)
       && this.index === prevout.index;
   }
 

--- a/lib/outpoint.spec.js
+++ b/lib/outpoint.spec.js
@@ -64,16 +64,24 @@ describe('Outpoint', () => {
   });
 
   it('should allow to compare', () => {
-    const fromJSON1 = Outpoint.fromJSON({
+    const outpointCopy = Outpoint.fromJSON({
       hash: out1.txid(),
       index: 0,
     });
-    const fromJSON2 = Outpoint.fromJSON({
+    
+    const anotherIndexOutpoint = Outpoint.fromJSON({
       hash: out1.txid(),
       index: 1,
     });
-    assert(fromJSON1.equals(fromJSON1));
-    assert(!fromJSON1.equals(fromJSON2));
+
+    const anotherHashOutpoint = Outpoint.fromJSON({
+      hash: '0x8888888888888888888888888888888888888888888888888888888888888888',
+      index: 1,
+    });
+
+    assert(outpointCopy.equals(out1));
+    assert(!anotherIndexOutpoint.equals(out1));
+    assert(!anotherHashOutpoint.equals(out1));
   });
 
   it('should instantiate an outpoint from a tx', () => {


### PR DESCRIPTION
Outpoint.hash is always Buffer, so should be compared with `equals`, not `===`.