### PR TITLE
feat: copy token data for NSTs in calcOutputs

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -640,11 +640,11 @@ export default class Transaction {
         output.color === color &&
         output.address.toLowerCase() === from.toLowerCase()
     );
-  
+
     const exact = myUnspent.find(utxo =>
       equal(BigInt(utxo.output.value), BigInt(amount))
     );
-  
+
     if (exact) return [new Input(exact.outpoint)];
   
     const inputs = [];
@@ -674,8 +674,15 @@ export default class Transaction {
   
     const inInputs = u =>
       inputs.findIndex(input => u.outpoint.equals(input.prevout)) > -1;
-    const sum = unspent
-      .filter(inInputs)
+    const inputUtxos = unspent.filter(inInputs);
+
+    if (Util.isNFT(color) || Util.isNST(color)) {
+      return inputUtxos.map(i =>
+        new Output(i.output.value, to, color, i.output.data)  
+      );
+    }
+
+    const sum = inputUtxos
       .reduce((a, u) => add(a, BigInt(u.output.value)), BigInt(0));
   
     if (lessThan(sum, BigInt(amount))) {

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -15,6 +15,11 @@ const ADDR = '0x82e8c6cf42c8d1ff9594b17a3f50e94a12cc860f';
 const ADDR_1 = '0x4436373705394267350db2c06613990d34621d69';
 const ADDR_2 = '0x8ab21c65041778dfc7ec7995f9cdef3d5221a5ad';
 
+const NFT_COLOR_BASE = 32769; // 2^15 + 1
+const NST_COLOR_BASE = 49153; // 2^15 + 1 + 2^14
+const tokenId = '0x0000000000000000000000005555555555555555555555555555555555555555';
+const tokenData = '0x00000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00005';
+
 const web3 = Web3([ADDR], [PRIV]);
 
 const bigEqual = (a, b) => equal(a, BigInt(b));
@@ -343,13 +348,9 @@ describe('transactions', () => {
 
   it('should allow to create and parse spending condition with different tokens', () => {
     const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
-    const NFT_COLOR_BASE = 32769; // 2^15 + 1
-    const NST_COLOR_BASE = 49153; // 2^15 + 1 + 2^14
     const multiCondition = '608060405234801561001057600080fd5b506004361061002e5760e060020a60003504635bac6c1e8114610033575b600080fd5b6100656004803603606081101561004957600080fd5b5080359060208101359060400135600160a060020a0316610067565b005b6040805160e060020a63a983d43f0281526004810185905260248101849052905173333333333333333333333333333333333333333391829163a983d43f9160448082019260009290919082900301818387803b1580156100c757600080fd5b505af11580156100db573d6000803e3d6000fd5b50506040805160e060020a6323b872dd028152306004820152600160a060020a038616602482015260448101889052905173555555555555555555555555555555555555555593508392506323b872dd9160648082019260009290919082900301818387803b15801561014d57600080fd5b505af1158015610161573d6000803e3d6000fd5b50506040805160e060020a6370a082310281523060048201529051735555555555555555555555555555555555555555935083925063a9059cbb91879184916370a08231916024808301926020929190829003018186803b1580156101c557600080fd5b505afa1580156101d9573d6000803e3d6000fd5b505050506040513d60208110156101ef57600080fd5b50516040805160e060020a63ffffffff8616028152600160a060020a03909316600484015260248301919091525160448083019260209291908290030181600087803b15801561023e57600080fd5b505af1158015610252573d6000803e3d6000fd5b505050506040513d602081101561026857600080fd5b50506040805160e060020a6370a08231028152306004820152905173555555555555555555555555555555555555555591829163a9059cbb91889184916370a08231916024808301926020929190829003018186803b1580156102ca57600080fd5b505afa1580156102de573d6000803e3d6000fd5b505050506040513d60208110156102f457600080fd5b50516040805160e060020a63ffffffff8616028152600160a060020a03909316600484015260248301919091525160448083019260209291908290030181600087803b15801561034357600080fd5b505af1158015610357573d6000803e3d6000fd5b505050506040513d602081101561036d57600080fd5b50505050505050505056fea165627a7a72305820d7e59872f6aca528c464ba6ba8a6b0c3534f9d6a54b403ab31f20b610056eb2a0029';
     const script = Buffer.from(multiCondition, 'hex');
     const scriptHash = ethUtil.ripemd160(script);
-    const tokenId = '0x0000000000000000000000005555555555555555555555555555555555555555';
-    const tokenData = '0x00000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00005';
     const receiver = '0x82e8C6Cf42C8D1fF9594b17A3F50e94a12cC860f'.toLowerCase();
     const gasAllowance = 6000000 * 100;
 
@@ -528,6 +529,61 @@ describe('transactions', () => {
       expect(outputs2[1].address).to.eq(ADDR_1);
       expect(bigEqual(outputs1[1].value, 150));
     });
+
+    it('should work for NFT', () => {
+      const color = NFT_COLOR_BASE;
+      const value = 123456;
+      const nftDeposit = Tx.deposit(3, value, ADDR_1, color);
+      const utxos = [
+        ...unspent,
+        { output: nftDeposit.outputs[0], outpoint: new Outpoint(nftDeposit.hash(), 0) }
+      ];
+      const inputs = calcInputs(utxos, ADDR_1, value, color);
+      const outputs = calcOutputs(utxos, inputs, ADDR_1, ADDR_2, value, color);
+      expect(outputs.length).to.eq(1);
+      expect(outputs[0].address).to.eq(ADDR_2);
+      expect(bigEqual(outputs[0].value, value));
+    });
+
+    it('should work for multiple NFT inputs', () => {
+      const color = NFT_COLOR_BASE;
+      const value = 123456;
+      const nftDeposit1 = Tx.deposit(3, value, ADDR_1, color);
+      const nftDeposit2 = Tx.deposit(3, 76890, ADDR_1, color);
+      const utxos = [
+        ...unspent,
+        { output: nftDeposit1.outputs[0], outpoint: new Outpoint(nftDeposit1.hash(), 0) },
+        { output: nftDeposit2.outputs[0], outpoint: new Outpoint(nftDeposit2.hash(), 0) }
+      ];
+
+      const inputs = [
+        new Input(new Outpoint(nftDeposit1.hash(), 0)),
+        new Input(new Outpoint(nftDeposit2.hash(), 0)),
+      ];
+
+      const outputs = calcOutputs(utxos, inputs, ADDR_1, ADDR_2, null, color);
+      expect(outputs.length).to.eq(2);
+      expect(outputs[0].address).to.eq(ADDR_2);
+      expect(bigEqual(outputs[0].value, value));
+      expect(outputs[1].address).to.eq(ADDR_2);
+      expect(bigEqual(outputs[1].value, 76890));
+    });
+
+    it('should copy input data for NST', () => {
+      const color = NST_COLOR_BASE;
+      const nstDeposit = Tx.deposit(4, tokenId, ADDR_1, color, tokenData);
+      const utxos = [
+        ...unspent,
+        { output: nstDeposit.outputs[0], outpoint: new Outpoint(nstDeposit.hash(), 0) }
+      ];
+      const inputs = calcInputs(utxos, ADDR_1, tokenId, color);
+      const outputs = calcOutputs(utxos, inputs, ADDR_1, ADDR_2, tokenId, color);
+      expect(outputs.length).to.eq(1);
+      expect(outputs[0].address).to.eq(ADDR_2);
+      expect(bigEqual(outputs[0].value, tokenId));
+      expect(bigEqual(outputs[0].data, tokenData));
+    });
+
   });
 
   


### PR DESCRIPTION
So that we can use Tx helpers like `transferFromUtxos` to create NST transfers as well.

Requires #124 