### PR TITLE
feat: add to/from/value getters to Transaction class

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,3 +13,5 @@
  * Number of blocks per Period
  */
 export const BLOCKS_PER_PERIOD = 32;
+
+export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -546,7 +546,9 @@ export default class Transaction {
     if (this.type === Type.TRANSFER) {
       json.to = this.to();
       json.from = this.from(prevTx);
-      json.value = this.value(prevTx);
+      const { value, color } = this.value(prevTx);
+      json.value = value;
+      json.color = color;
     }
 
     if (this.isSigned()) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -21,6 +21,7 @@ import Output, { OUT_LENGTH, NST_OUT_LENGTH } from './output';
 import Outpoint from './outpoint';
 import Util from './util';
 import Type from './type';
+import { EMPTY_ADDRESS } from './constants';
 
 const EMPTY_BUF = Buffer.alloc(32, 0);
 
@@ -350,6 +351,72 @@ export default class Transaction {
   // Checks if this tx is equal to `another`
   equals(another) {
     return this.toRaw().equals(another.toRaw());
+  }
+
+  /**
+   * Returns perceived "value" of the transaction and it's color.
+   * 
+   * If tx has outputs, the first outputs is considered as a value bearing.
+   * For Exit transactions, returns the value of the connected output of 
+   * the previous tx (if provided).
+   * 
+   * @param {Transaction} prevTx (optional) previous tx connected to the first input's outpoint
+   * @returns {object} { value, color }
+   */
+  value(prevTx = null) {
+    // assuming first output is transfer, second one is change
+    if (this.outputs && this.outputs.length > 0) {
+      const { value, color } = this.outputs[0];
+      return { value, color };
+    }
+
+    if (this.type === Type.EXIT && prevTx) {
+      const { value, color } = prevTx.outputs[this.inputs[0].prevout.index];
+      return { value, color };
+    }
+
+    return { value: BigInt(0), color: 0 };
+  }
+
+  /**
+   * Returns perceived "from" address.
+   * 
+   * If tx has inputs, the first input is considered as a source.
+   * Address is either:
+   * 1. address of the connected output of the previous tx (if provided)
+   * 2. signer of the first input (if tx is signed)
+   * 
+   * Returns null address, if neither prevTx provided nor tx is signed.
+   * 
+   * @param {Transaction} prevTx (optional) previous tx connected to the first input's outpoint
+   * @returns {string} address
+   */
+  from(prevTx = null) {
+    if (!this.inputs || !this.inputs.length) {
+      return EMPTY_ADDRESS;
+    }
+
+    if (prevTx && prevTx.hashBuf().equals(this.inputs[0].prevout.hash)) {
+      return prevTx.outputs[this.inputs[0].prevout.index].address;
+    }
+
+    return this.inputs[0].signer || EMPTY_ADDRESS;
+  }
+
+/**
+   * Returns perceived "to" address.
+   * 
+   * If tx has outputs, the first outputs is considered as a destination.   * 
+   * Returns null address, if tx has no outputs
+   * 
+   * @returns {string} address
+   */
+  to() {
+    if (!this.outputs || !this.outputs.length) {
+      return EMPTY_ADDRESS;
+    }
+    
+    return this.outputs[0].address;
   }
 
   /**

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -536,12 +536,18 @@ export default class Transaction {
   /* eslint-enable prefer-destructuring */
 
 
-  toJSON() {
+  toJSON(prevTx = null) {
     const json = {
       type: this.type,
       inputs: this.inputs.map(inp => inp.toJSON()),
       outputs: this.outputs.map(out => out.toJSON()),
     };
+
+    if (this.type === Type.TRANSFER) {
+      json.to = this.to();
+      json.from = this.from(prevTx);
+      json.value = this.value(prevTx);
+    }
 
     if (this.isSigned()) {
       json.hash = this.hash();

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -149,10 +149,8 @@ describe('transactions', () => {
       outputs: [{ address: ADDR, value: value.toString(), color }],
       to: ADDR,
       from: ADDR_2,
-      value: {
-        color,
-        value
-      }
+      value,
+      color,
     });
     // fromJSON
     assert.deepEqual(Tx.fromJSON(json), transfer);
@@ -188,10 +186,8 @@ describe('transactions', () => {
       outputs: [{ address: ADDR, value: value.toString(), color }],
       to: ADDR,
       from: ADDR, // input signed by ADDR
-      value: {
-        color,
-        value
-      }
+      value,
+      color,
     });
     // fromJSON
     assert.deepEqual(Tx.fromJSON(json), transfer);

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -9,6 +9,7 @@ import Type from './type';
 import Input from './input';
 import Output from './output';
 import Outpoint from './outpoint';
+import { EMPTY_ADDRESS } from './constants';
 
 const PRIV = '0x94890218f2b0d04296f30aeafd13655eba4c5bbf1770273276fee52cbe3f2cb4';
 const ADDR = '0x82e8c6cf42c8d1ff9594b17a3f50e94a12cc860f';
@@ -602,7 +603,84 @@ describe('transactions', () => {
       expect(bigEqual(outputs[0].value, tokenId));
       expect(bigEqual(outputs[0].data, tokenData));
     });
+  });
 
+  describe('#to', () => {
+    it('returns address of the first output', async () => {
+      const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+      const tx = Tx.transfer(
+        [new Input(new Outpoint(prevTx, 0))],
+        [
+          new Output(10, ADDR_1, 0),
+          new Output(20, ADDR_2, 0)
+        ],
+      );
+      expect(tx.to()).to.eq(ADDR_1);
+    });
+
+    it('returns null address if no outputs', async () => {
+      const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+      const tx = Tx.exit(new Input(new Outpoint(prevTx, 0)));
+      expect(tx.to()).to.eq(EMPTY_ADDRESS);
+    });
+  });
+
+  describe('#from', () => {
+    it('returns address of the first prevOut if provided', async () => {
+      const prevTx = Tx.deposit(4, 30, ADDR_2);
+      const tx = Tx.transfer(
+        [new Input(new Outpoint(prevTx.hash(), 0))],
+        [
+          new Output(10, ADDR_1, 0),
+          new Output(20, ADDR_2, 0)
+        ],
+      );
+      expect(tx.from(prevTx)).to.eq(ADDR_2);
+    });
+
+    it('returns signer of the first input', async () => {
+      const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+      const tx = Tx.transfer(
+        [new Input(new Outpoint(prevTx, 0))],
+        [
+          new Output(10, ADDR_1, 0),
+          new Output(20, ADDR_2, 0)
+        ],
+      ).signAll(PRIV);
+      expect(tx.from()).to.eq(ADDR);
+    });
+
+    it('returns null address if no inputs', async () => {
+      const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+      const tx = Tx.exit(new Input(new Outpoint(prevTx, 0)));
+      expect(tx.to()).to.eq(EMPTY_ADDRESS);
+    });
+  });
+
+  describe('#value', () => {
+    it('returns 0 if no outputs and no prevTx provided', async () => {
+      const prevTx = Tx.deposit(4, 30, ADDR_2, 1);
+      const tx = Tx.exit(new Input(new Outpoint(prevTx.hash(), 0)));
+      expect(tx.value()).to.deep.eq({ value: BigInt(0), color: 0 });
+    });
+
+    it('returns value of the first output', async () => {
+      const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+      const tx = Tx.transfer(
+        [new Input(new Outpoint(prevTx, 0))],
+        [
+          new Output(10, ADDR_1, 1),
+          new Output(20, ADDR_2, 1)
+        ],
+      ).signAll(PRIV);
+      expect(tx.value()).to.deep.eq({ value: BigInt(10), color: 1 });
+    });
+
+    it('returns value of the first prevOut for Exit tx', async () => {
+      const prevTx = Tx.deposit(4, 30, ADDR_2, 1);
+      const tx = Tx.exit(new Input(new Outpoint(prevTx.hash(), 0)));
+      expect(tx.value(prevTx)).to.deep.eq({ value: BigInt(30), color: 1 });
+    });
   });
 
 

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -133,25 +133,26 @@ describe('transactions', () => {
     // vote.inputs[0].signer
   });
 
-  it('should allow to serialze and deserialize unsigned transfer tx to/from json.', () => {
-    const prevTx = '0x7777777777777777777777777777777777777777777777777777777777777777';
+  it('should allow to serialize and deserialize unsigned transfer tx to/from json.', () => {
+    const prevTx = Tx.deposit(4, 30, ADDR_2);
     const value = BigInt('99000000');
     const color = 1337;
     const transfer = Tx.transfer(
-      [new Input(new Outpoint(prevTx, 0))],
+      [new Input(new Outpoint(prevTx.hash(), 0))],
       [new Output(value, ADDR, color)],
     );
 
-    const json = transfer.toJSON();
+    const json = transfer.toJSON(prevTx);
     expect(json).to.eql({
       type: Type.TRANSFER,
-      inputs: [
-        {
-          hash: '0x7777777777777777777777777777777777777777777777777777777777777777',
-          index: 0,
-        },
-      ],
+      inputs: [{ hash: prevTx.hash(), index: 0, }],
       outputs: [{ address: ADDR, value: value.toString(), color }],
+      to: ADDR,
+      from: ADDR_2,
+      value: {
+        color,
+        value
+      }
     });
     // fromJSON
     assert.deepEqual(Tx.fromJSON(json), transfer);
@@ -185,6 +186,12 @@ describe('transactions', () => {
         },
       ],
       outputs: [{ address: ADDR, value: value.toString(), color }],
+      to: ADDR,
+      from: ADDR, // input signed by ADDR
+      value: {
+        color,
+        value
+      }
     });
     // fromJSON
     assert.deepEqual(Tx.fromJSON(json), transfer);


### PR DESCRIPTION
Moving common code to "optimistically presume" `to`/`from`/`value` of the transaction  from [leap-node](https://github.com/leapdao/leap-node/blob/5dc77eda64dd3949a88b95a511fc0ab931e841b5/src/api/methods/txResponse.js).

Intended to work for "standard" transactions under assumptions:
- one tx — one signer (all the inputs are from the same account)
- one tx — one beneficiary/destination (first output)