### PR TITLE
feat: add CAS support for helpers.getProof

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -318,6 +318,14 @@ declare module "leap-core" {
     outputs: Output[];
   };
 
+  type PeriodData = {
+    validatorAddress: string;
+    slotId: number;
+    casBitmap: string;
+    periodStart: number;
+    periodEnd: number;
+  };
+
   class ExtendedWeb3 extends Web3 {
     public getUnspent(address: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspent(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
@@ -328,6 +336,7 @@ declare module "leap-core" {
     public getConfig(cb?: Callback<NodeConfig>): Promise<NodeConfig>;
     public getValidatorInfo(cb?: Callback<ValidatorInfo>): Promise<ValidatorInfo>;
     public checkSpendingCondition(tx: Transaction<Type.SPEND_COND>, cb?: Callback<SpendCondSimResult>): Promise<SpendCondSimResult>;
+    public getPeriodByBlockHeight(blockHeight: number): Promise<PeriodData>;
   }
 
   namespace helpers {
@@ -338,7 +347,7 @@ declare module "leap-core" {
     export function periodBlockRange(blockNumber: number): Array<number>[2];
     export function getTxWithYoungestBlock(txs: LeapTransaction[]): InputTx;
     export function getYoungestInputTx(plasma: ExtendedWeb3, tx: Tx<any>): Promise<InputTx>;
-    export function getProof(plasma: ExtendedWeb3, tx: LeapTransaction, slotId: number, validatorAddr: string): Promise<Proof>;
+    export function getProof(plasma: ExtendedWeb3, tx: LeapTransaction): Promise<Proof>;
     // Depending on plasma instance, resolves to either Web3's Transaction or Ethers' TransactionReceipt
     export function sendSignedTransaction(plasma: ExtendedWeb3, tx: string): Promise<any>;
     export function simulateSpendCond(plasma: ExtendedWeb3, tx: Transaction<Type.SPEND_COND>): Promise<SpendCondSimResult>;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -240,9 +240,9 @@ export function getYoungestInputTx(plasma, tx) {
  * @param {LeapTransaction} tx
  * @returns {Promise<Proof>} promise that resolves to period inclusion proof
  */
-export function getProof(plasma, tx, slotId, validatorAddr) {
+export function getProof(plasma, tx, slotId, validatorAddr, casBitmap) {
   return Period.periodForTx(plasma, tx).then(period => {
-    period.setValidatorData(slotId, validatorAddr);
+    period.setValidatorData(slotId, validatorAddr, casBitmap);
     return period.proof(Tx.fromRaw(tx.raw));
   });
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -252,12 +252,10 @@ export function getYoungestInputTx(plasma, tx) {
  * @returns {Promise<Proof>} promise that resolves to period inclusion proof
  */
 export function getProof(plasma, tx) {
-  return Period.periodForTx(plasma, tx)
-    .then((period) => {
-      const periodData = plasma.getPeriodByBlockHeight(tx.blockNumber);
-      return Promise.all([period, periodData]);
-    })
-    .then(([period, periodData]) => {
+  return Promise.all([
+      Period.periodForTx(plasma, tx),
+      plasma.getPeriodByBlockHeight(tx.blockNumber)
+    ]).then(([period, periodData]) => {
       if (!periodData.length) {
         throw new Error(`No period data for the given tx. Height:${tx.blockHeight}`);
       }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -74,6 +74,10 @@ export class LeapEthers {
       outputs: outputs.map(Output.fromJSON),
     }));
   }
+
+  getPeriodByBlockHeight(blockHeight) {
+    return this.provider.send('plasma_getPeriodByBlockHeight', [blockHeight]);
+  }
 }
 
 export function extendWeb3(web3Instance) {
@@ -159,6 +163,13 @@ export function extendWeb3(web3Instance) {
           outputs: outputs.map(Output.fromJSON)
         }),
       }),
+      new extend.Method({
+        name: 'getPeriodByBlockHeight',
+        call: 'plasma_getPeriodByBlockHeight',
+        params: 1,
+        inputFormatters: [a => a],
+        outputFormatter: a => a,
+      }),
     ],
   });
 
@@ -240,11 +251,20 @@ export function getYoungestInputTx(plasma, tx) {
  * @param {LeapTransaction} tx
  * @returns {Promise<Proof>} promise that resolves to period inclusion proof
  */
-export function getProof(plasma, tx, slotId, validatorAddr, casBitmap) {
-  return Period.periodForTx(plasma, tx).then(period => {
-    period.setValidatorData(slotId, validatorAddr, casBitmap);
-    return period.proof(Tx.fromRaw(tx.raw));
-  });
+export function getProof(plasma, tx) {
+  return Period.periodForTx(plasma, tx)
+    .then((period) => {
+      const periodData = plasma.getPeriodByBlockHeight(tx.blockNumber);
+      return Promise.all([period, periodData]);
+    })
+    .then(([period, periodData]) => {
+      if (!periodData.length) {
+        throw new Error(`No period data for the given tx. Height:${tx.blockHeight}`);
+      }
+      const { slotId, validatorAddress, casBitmap } = periodData[0];
+      period.setValidatorData(slotId, validatorAddress, casBitmap);
+      return period.proof(Tx.fromRaw(tx.raw));
+    });
 }
 
 /**

--- a/lib/helpers.spec.js
+++ b/lib/helpers.spec.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { bi } from 'jsbi-utils';
 
 import Tx from './transaction';
 import Outpoint from './outpoint';
@@ -9,25 +10,23 @@ import {
   getYoungestInputTx,
   periodBlockRange,
   consolidateUTXOs,
+  getProof,
 } from './helpers';
 import Input from './input';
-import { bi } from 'jsbi-utils';
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
 
-
 describe('helpers', () => {
   const ADDR_1 = '0x4436373705394267350db2c06613990d34621d69';
   const ADDR_2 = '0x8ab21c65041778dfc7ec7995f9cdef3d5221a5ad';
-
 
   const prevTx =
     '0x7777777777777777777777777777777777777777777777777777777777777777';
 
   const transfer = Tx.transfer(
     [new Input(new Outpoint(prevTx, 0)), new Input(new Outpoint(prevTx, 1))],
-    [new Output(10, ADDR_1, 0)],
+    [new Output(10, ADDR_1, 0)]
   );
 
   const tx1 = {
@@ -166,6 +165,44 @@ describe('helpers', () => {
       expect(() => {
         consolidateUTXOs(utxos);
       }).to.throw('Expected UTXOs only for one address, got 2');
+    });
+  });
+
+  describe('getProof', () => {
+    it('should get CAS proof', async () => {
+      const value = 50000000;
+      const color = 1337;
+      const deposit1 = Tx.deposit(0, value, ADDR_1, color);
+
+      const casBitmap =
+        '0x4000000000000000000000000000000000000000000000000000000000000000';
+      const plasma = {
+        getBlock: n => {
+          expect(n).to.be.within(0, 32);
+          const transactions = n === 4 ? [{ raw: deposit1.hex() }] : [];
+          return { number: n, timestamp: 123, transactions };
+        },
+        getPeriodByBlockHeight: n => {
+          expect(n).to.be.equal(4);
+          return [{ slotId: 0, validatorAddress: ADDR_1, casBitmap }];
+        },
+      };
+
+      const proof = getProof(plasma, { blockNumber: 4, raw: deposit1.hex() });
+      return expect(proof).to.eventually.eql([
+        '0x6eefe22ae29bc837d66e743334a70ecc19635c3c9ef31d4c2987b337b9d015c6',
+        '0x4404003c00000000000000080000000000000000000000000000000000000000',
+        '0x0000000002110000000000000000000000000000000000000000000000000000',
+        '0x00000000000002faf08005394436373705394267350db2c06613990d34621d69',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5',
+        '0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30',
+        '0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85',
+        '0xe58769b32a1beaf1ea27375a44095a0d1fb664ce2dd358e7fcbfb78c26a19344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0xce66be6d62350d88a9edfd6b4a67eac3d06e8846583ff5a56d939dd20cdbf6cb',
+      ]);
     });
   });
 });

--- a/lib/period.js
+++ b/lib/period.js
@@ -57,6 +57,7 @@ export default class Period {
   }
 
   setValidatorData(slotId, ownerAddr, casBitmap) {
+    console.log(slotId, ownerAddr, casBitmap, toBuffer(ownerAddr))
     this.slotId = slotId;
     this.ownerAddr = toBuffer(ownerAddr);
     if (casBitmap) {

--- a/lib/period.js
+++ b/lib/period.js
@@ -57,7 +57,6 @@ export default class Period {
   }
 
   setValidatorData(slotId, ownerAddr, casBitmap) {
-    console.log(slotId, ownerAddr, casBitmap, toBuffer(ownerAddr))
     this.slotId = slotId;
     this.ownerAddr = toBuffer(ownerAddr);
     if (casBitmap) {


### PR DESCRIPTION
- added `plasma_getPeriodByBlockHeight` JSON RPC extension ([docs](https://github.com/leapdao/leapdao-docs/pull/39))
- improved `getProof` helper so it fetches period data automatically:

```ts
helpers.getProof(plasma: ExtendedWeb3 | LeapEthers, tx: LeapTransaction)
```

Resolves #115 