### PR TITLE
Fix: better getUnspent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -328,6 +328,7 @@ declare module "leap-core" {
 
   class ExtendedWeb3 extends Web3 {
     public getUnspent(address: string | undefined | null, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address: string | undefined | null, tokenAddress: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspent(address?: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -327,7 +327,7 @@ declare module "leap-core" {
   };
 
   class ExtendedWeb3 extends Web3 {
-    public getUnspent(address?: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address: string | undefined, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspent(address?: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -327,8 +327,8 @@ declare module "leap-core" {
   };
 
   class ExtendedWeb3 extends Web3 {
-    public getUnspent(address: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
-    public getUnspent(address: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address?: string, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address?: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;
     public getColors(cb?: Callback<string[]>): Promise<string[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -327,7 +327,7 @@ declare module "leap-core" {
   };
 
   class ExtendedWeb3 extends Web3 {
-    public getUnspent(address: string | undefined, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
+    public getUnspent(address: string | undefined | null, color: number, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspent(address?: string, cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getUnspentAll(cb?: Callback<Array<Unspent>>): Promise<Array<Unspent>>;
     public getColor(tokenContractAddress: string, cb?: Callback<number>): Promise<number>;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -255,6 +255,8 @@ const send = (plasma, txHex) => {
  * @returns {Promise<Receipt>} promise that resolves to a transaction receipt
  */
 export function sendSignedTransaction(plasma, txHex) {
+  // eslint-disable-next-line no-console
+  console.warn('DEPRECATED: use Web3#sendSignedTransaction or LeapProvider#sendTransaction instead');
   return send(plasma, txHex).then((resp) => {
     return awaitForReceipt(resp, Promise.resolve(), plasma, 0);
   });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,10 +39,12 @@ export class LeapEthers {
   }
 
   getUnspentByAddress(...params) {
+    console.warn('DEPRECATED: use getUnspent(address) instead'); // eslint-disable-line no-console
     return this.getUnspent(params);
   }
 
   getUnspentAll() {
+    console.warn('DEPRECATED: use getUnspent() instead'); // eslint-disable-line no-console
     return this.provider
       .send('plasma_unspent', [])
       .then(unspent => unspent.map(fromRaw));

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,75 +12,10 @@ import Outpoint from './outpoint';
 import Period from './period';
 import Tx from './transaction';
 
-function getLowerCase(value) {
-  if (value) {
-    return value.toLowerCase();
-  }
-  return value;
-}
-
 const fromRaw = u => ({
   output: u.output,
   outpoint: Outpoint.fromRaw(u.outpoint),
 });
-
-export class LeapEthers {
-  /**
-   * @param { import("ethers").providers.JsonRpcProvider } provider
-   */
-  constructor(provider) {
-    this.provider = provider;
-  }
-
-  getUnspent(...params) {
-    return this.provider
-      .send('plasma_unspent', params.map(getLowerCase))
-      .then(unspent => unspent.map(fromRaw));
-  }
-
-  getUnspentByAddress(...params) {
-    console.warn('DEPRECATED: use getUnspent(address) instead'); // eslint-disable-line no-console
-    return this.getUnspent(params);
-  }
-
-  getUnspentAll() {
-    console.warn('DEPRECATED: use getUnspent() instead'); // eslint-disable-line no-console
-    return this.provider
-      .send('plasma_unspent', [])
-      .then(unspent => unspent.map(fromRaw));
-  }
-
-  getColor(...params) {
-    return this.provider.send('plasma_getColor', params.map(getLowerCase));
-  }
-
-  getColors() {
-    return this.provider.send('plasma_getColors', []);
-  }
-
-  status() {
-    return this.provider.send('plasma_status', []);
-  }
-
-  getConfig() {
-    return this.provider.send('plasma_getConfig', []);
-  }
-
-  getValidatorInfo() {
-    return this.provider.send('validator_getAddress', []);
-  }
-
-  checkSpendingCondition(tx) {
-    return this.provider.send('checkSpendingCondition', [tx.hex()]).then(({ error, outputs }) => ({
-      error,
-      outputs: outputs.map(Output.fromJSON),
-    }));
-  }
-
-  getPeriodByBlockHeight(blockHeight) {
-    return this.provider.send('plasma_getPeriodByBlockHeight', [blockHeight]);
-  }
-}
 
 export function extendWeb3(web3Instance) {
   // `_extend` for web3 0.2x.x, `extend` for 1.x
@@ -336,7 +271,7 @@ export function consolidateUTXOs(utxos) {
 /**
  * Returns outputs for spending condition tx
  *
- * @param {ExtendedWeb3 | LeapEthers} plasma
+ * @param {ExtendedWeb3 | LeapProvider} plasma
  * @param {LeapTransaction} tx
  *
  * @returns {Promise<Output>}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -171,7 +171,7 @@ export function getTxWithYoungestBlock(txs) {
  * Returns the youngest input for a given tx.
  *
  * Youngest input is the one which references tx with biggest block number.
- * @param {ExtendedWeb3} plasma instance of Leap Web3
+ * @param {ExtendedWeb3|LeapProvider} plasma instance of Leap Web3
  * @param {Tx} tx
  * @returns {Promise<InputTx>} promise that resolves to youngest input tx and its index
  */
@@ -184,7 +184,7 @@ export function getYoungestInputTx(plasma, tx) {
 /**
  * Creates proof of period inclusion for a given tx
  *
- * @param {ExtendedWeb3} plasma instance of Leap Web3
+ * @param {ExtendedWeb3|LeapProvider} plasma instance of Leap Web3
  * @param {LeapTransaction} tx
  * @returns {Promise<Proof>} promise that resolves to period inclusion proof
  */
@@ -251,7 +251,7 @@ const send = (plasma, txHex) => {
  * Sends a signed transaction to the node
  *
  * @param {ExtendedWeb3} plasma instance of Leap Web3 or JSONRPCProvider of Ethers.js
- * @param {LeapTransaction} txHex - transaction to send
+ * @param {string} txHex - transaction to send
  * @returns {Promise<Receipt>} promise that resolves to a transaction receipt
  */
 export function sendSignedTransaction(plasma, txHex) {
@@ -272,9 +272,9 @@ export function consolidateUTXOs(utxos) {
  * Returns outputs for spending condition tx
  *
  * @param {ExtendedWeb3 | LeapProvider} plasma
- * @param {LeapTransaction} tx
+ * @param {Tx} tx
  *
- * @returns {Promise<Output>}
+ * @returns {Promise<Array<Output>>}
  */
 export function simulateSpendCond(plasma, tx) {
   return plasma.checkSpendingCondition(tx);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,6 +17,21 @@ const fromRaw = u => ({
   outpoint: Outpoint.fromRaw(u.outpoint),
 });
 
+const paddedParams = (params) => {
+  const hasCb = typeof params[params.length - 1] === 'function';
+  const paramCount = hasCb ? params.length - 1 : params.length;
+
+  if (paramCount === 0) { // getUnspent()
+    return ['', '', ...params];
+  }
+
+  if (paramCount === 1) { // getUnspent(address)
+    return [params[0], '', ...params.splice(1)];
+  }
+
+  return params; // getUnspent(address, color)
+};
+
 export function extendWeb3(web3Instance) {
   // `_extend` for web3 0.2x.x, `extend` for 1.x
   const extend = web3Instance._extend || web3Instance.extend; // eslint-disable-line no-underscore-dangle, max-len
@@ -41,17 +56,7 @@ export function extendWeb3(web3Instance) {
     methods: [
       new extend.Method({
         ...getUnspent,
-        name: 'getUnspentByAddress',
-        params: 1,
-      }),
-      new extend.Method({
-        ...getUnspent,
-        name: 'getUnspentByAddressColor',
-      }),
-      new extend.Method({
-        ...getUnspent,
-        name: 'getUnspentAll',
-        params: 0,
+        name: '_getUnspent',
       }),
       new extend.Method({
         name: 'getColor',
@@ -110,15 +115,23 @@ export function extendWeb3(web3Instance) {
     ],
   });
 
-  web3Instance.getUnspent = (...params) => {
-    const last = params[params.length - 1];
-    const hasCb = typeof last === 'function';
-    if (params.length === (hasCb ? 2 : 1)) {
-      return web3Instance.getUnspentByAddress(...params);
-    }
-
-    return web3Instance.getUnspentByAddressColor(...params);
+  web3Instance.getUnspentAll = (...params) => {
+    console.warn('DEPRECATED: use getUnspent() instead'); // eslint-disable-line no-console
+    return web3Instance.getUnspent(...params);
   };
+
+  web3Instance.getUnspentByAddress = (...params) => {
+    console.warn('DEPRECATED: use getUnspent(address) instead'); // eslint-disable-line no-console
+    return web3Instance.getUnspent(...params);
+  };
+
+  web3Instance.getUnspentByAddressColor = (...params) => {
+    console.warn('DEPRECATED: use getUnspent(address, color) instead'); // eslint-disable-line no-console
+    return web3Instance.getUnspent(...params);
+  };
+
+  web3Instance.getUnspent = (...params) => 
+    web3Instance._getUnspent(...paddedParams(params)); // eslint-disable-line no-underscore-dangle
 
   return web3Instance;
 }


### PR DESCRIPTION
- deprecates getUnspentAll and getUnspentByAddress #139
- allow to get all utxos by color with `getUnspent(null, 1)` #137 
- drop LeapEthers in favour of LeapProvider https://github.com/leapdao/leap-provider/pull/3
