### PR TITLE
fix: getColors should accept two optional params

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -68,10 +68,10 @@ export function extendWeb3(web3Instance) {
         outputFormatter: Number,
       }),
       new extend.Method({
-        name: 'getColors',
+        name: '_getColors',
         call: 'plasma_getColors',
-        params: 0,
-        inputFormatters: [],
+        params: 2,
+        inputFormatters: [a => a, a => a],
         outputFormatter: String,
       }),
       new extend.Method({
@@ -133,6 +133,9 @@ export function extendWeb3(web3Instance) {
   web3Instance.getUnspent = (...params) => 
     web3Instance._getUnspent(...paddedParams(params)); // eslint-disable-line no-underscore-dangle
 
+  web3Instance.getColors = (...params) =>
+    web3Instance._getColors(...paddedParams(params)); // eslint-disable-line no-underscore-dangle
+  
   return web3Instance;
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,8 +133,27 @@ export function extendWeb3(web3Instance) {
   web3Instance.getUnspent = (...params) => 
     web3Instance._getUnspent(...paddedParams(params)); // eslint-disable-line no-underscore-dangle
 
-  web3Instance.getColors = (...params) =>
-    web3Instance._getColors(...paddedParams(params)); // eslint-disable-line no-underscore-dangle
+  /* eslint-disable no-underscore-dangle */
+  web3Instance.getColors = (type) => {
+    const typeStr = (type || '').toLowerCase();
+    if (typeStr === 'erc721' || typeStr === 'nft') {
+      return web3Instance._getColors(true, null);
+    }
+    if (typeStr === 'erc1948' || type === 'nst') {
+      return web3Instance._getColors(false, true);
+    }
+
+    if (typeStr === 'erc20') {
+      return web3Instance._getColors(false, false);
+    }
+
+    return Promise.all([
+      web3Instance._getColors(false, false),
+      web3Instance._getColors(true, false),
+      web3Instance._getColors(false, true),
+    ]).then(([erc20, erc721, erc1948]) => ({ erc20, erc721, erc1948 }));
+  }
+  /* eslint-enable no-underscore-dangle */
   
   return web3Instance;
 }


### PR DESCRIPTION
Resolves #144 

preserves backward compatibility with just `getColor()`.

Overall, all the three cases should be supported:
```
// erc20
plasma.getColor()

// erc721
plasma.getColor(true)

// erc1948
plasma.getColor(false, true)
```