### PR TITLE
feat: allow to cap number of inputs for calcInputs

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -714,7 +714,7 @@ export default class Transaction {
     }
   }
 
-  static calcInputs(unspent, from, amount, color = 0) {
+  static calcInputs(unspent, from, amount, color = 0, limit) {
     const myUnspent = unspent.filter(
       ({ output }) =>
         output.color === color &&
@@ -734,6 +734,17 @@ export default class Transaction {
       sum = add(sum, BigInt(myUnspent[i].output.value));
 
       if (greaterThanOrEqual(sum, BigInt(amount))) {
+        break;
+      }
+      if (limit && inputs.length + 1 === limit) {
+        const diff = subtract(BigInt(amount), sum);
+        const oneMore = myUnspent
+          .slice(i + 1).find(u => greaterThanOrEqual(BigInt(u.output.value), diff));
+
+        if (oneMore) {
+          inputs.push(new Input(oneMore.outpoint));
+          sum = add(sum, BigInt(oneMore.output.value));
+        }
         break;
       }
     }

--- a/lib/transaction.spec.js
+++ b/lib/transaction.spec.js
@@ -507,6 +507,28 @@ describe('transactions', () => {
         deposit2.hash(),
       );
     });
+
+    it('should use limit if provided', async () => {
+      const deposit3 = Tx.deposit(2, 100, ADDR_1);
+      const deposit4 = Tx.deposit(2, 400, ADDR_1);
+      const moreUnspent = [
+        ...unspent,
+        { output: deposit3.outputs[0], outpoint: new Outpoint(deposit3.hash(), 0) },
+        { output: deposit4.outputs[0], outpoint: new Outpoint(deposit4.hash(), 0) },
+      ];
+
+      const inputs1 = calcInputs(moreUnspent, ADDR_1, 350, 0, 2);
+      expect(inputs1.length).to.eq(2);
+      expect(ethUtil.bufferToHex(inputs1[0].prevout.hash)).to.eq(
+        deposit1.hash(),
+      );
+      expect(ethUtil.bufferToHex(inputs1[1].prevout.hash)).to.eq(
+        deposit4.hash(),
+      );
+      expect(() => 
+        calcInputs(moreUnspent, ADDR_1, 550, 0, 2)
+      ).to.throw('Not enough inputs');
+    });
   });
 
   describe('Tx.calcOutputs', () => {


### PR DESCRIPTION
Adds a half-assed option to limit an amount of inputs produced by `calcInputs`.

Requires https://github.com/leapdao/leap-core/pull/148