### PR TITLE
fix: set default color for Output and calcInput to 0

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -28,7 +28,7 @@ export default class Output {
     if (typeof valueOrObject === 'object' && !isBigInt(valueOrObject)) {
       Util.ensureSafeValue(valueOrObject.value);
       this.value = BigInt(valueOrObject.value);
-      this.color = valueOrObject.color;
+      this.color = valueOrObject.color || 0;
       this.address = valueOrObject.address;
 
       if (this.isNST()) {
@@ -38,7 +38,7 @@ export default class Output {
       Util.ensureSafeValue(valueOrObject);
       this.value = BigInt(valueOrObject);
       this.address = address;
-      this.color = color;
+      this.color = color || 0;
 
       if (this.isNST()) {
         this.data = data;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -714,7 +714,7 @@ export default class Transaction {
     }
   }
 
-  static calcInputs(unspent, from, amount, color) {
+  static calcInputs(unspent, from, amount, color = 0) {
     const myUnspent = unspent.filter(
       ({ output }) =>
         output.color === color &&


### PR DESCRIPTION
Otherwise it is `undefined` and `calcInputs` can lead to wrong results