### PR TITLE
Release 0.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leap-core",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "description": "transaction and block implementation",
   "main": "dist/index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
## Changed
- BREAKING CHANGE: `getColors()` RPC helper now returns all the colors instead of only erc20 (#145)

## Added
- `getColors` RPC helper now supports ERC721 and ERC1948 (#145):
   ```
   // erc20 + erc721 + erc1948
   plasma.getColors()

   // erc721
   plasma.getColors('erc20')

   // erc721
   plasma.getColors('erc721')

   // erc1948
  plasma.getColors('erc1948')
   ```