### PR TITLE
fix: Period.proof throwing incorrect error when tx is not in the period.

### DIFF
--- a/lib/period.js
+++ b/lib/period.js
@@ -105,7 +105,6 @@ export default class Period {
   }
 
   proof(tx) {
-    let blockPos;
     let periodPos = -1;
     for (let i = 0; i < this.blockList.length; i++) {
       const pos = this.blockList[i].txHashList.indexOf(tx.hash());
@@ -113,11 +112,10 @@ export default class Period {
         if (periodPos >= 0) {
           throw Error('tx doublespend');
         }
-        blockPos = pos;
         periodPos = i;
       }
     }
-    if (blockPos < 0) {
+    if (periodPos < 0) {
       throw Error('tx not in this period');
     }
     // get block proof in period

--- a/lib/period.spec.js
+++ b/lib/period.spec.js
@@ -40,6 +40,26 @@ describe('periods', () => {
     done();
   });
 
+  it('should throw if tx is not in the period', (done) => {
+    const value = 50000000;
+    const color = 1337;
+
+    const deposit1 = Tx.deposit(0, value, ADDR, color);
+    const block1 = new Block(1);
+    block1.addTx(deposit1);
+
+    const deposit2 = Tx.deposit(1, value, ADDR, color);
+    const block2 = new Block(2);
+    block2.addTx(deposit2);
+
+    const period = new Period(null, [block1]);
+    period.setValidatorData(slotId, ADDR);
+    expect(
+      () => period.proof(deposit2)
+    ).to.throw('tx not in this period');
+    done();
+  });
+
   it('should allow to get proof from period with CAS bitmap.', (done) => {
     const height = 123;
     const value = 50000000;


### PR DESCRIPTION
Reason: wrong check (blockPos is undefined, not negative)