### PR TITLE
chore(ci): add tests and coverage via Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Get yarn cache
+    - name: get yarn cache
       id: yarn-cache
       run: echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache node modules
+    - name: cache node modules
       uses: actions/cache@v1
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
+    - run: yarn install
     - name: lint
       run: yarn lint
     - name: tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: lint
+      run: npm run lint
+    - name: tests
+      run: nyc --reporter=lcov npm test
+    - name: upload coverage report
+      uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - run: npm install
+    - name: Get yarn cache
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: npm install -g yarn
     - name: lint
-      run: npm run lint
+      run: yarn lint
     - name: tests
-      run: ./node_modules/.bin/nyc --reporter=lcov npm test
+      run: ./node_modules/.bin/nyc --reporter=lcov yarn test
     - name: upload coverage report
       uses: codecov/codecov-action@v1.0.5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
-    - run: npm install -g yarn
     - name: lint
       run: yarn lint
     - name: tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - run: npm install
     - name: lint
       run: npm run lint
     - name: tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: lint
       run: npm run lint
     - name: tests
-      run: nyc --reporter=lcov npm test
+      run: ./node_modules/.bin/nyc --reporter=lcov npm test
     - name: upload coverage report
       uses: codecov/codecov-action@v1.0.5
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-  - '8.11'
-before_script: yarn global add codecov
-script:
-  - yarn lint
-  - yarn cover
-  - codecov


### PR DESCRIPTION
- Using Github Actions instead of Travis.
- Uploads coverage to codecov.io (wasn't uploaded with Travis)

Reason for Github Actions:
- native, no need to open external site
- once adopted, allow extra automations (e.g. greeting contributors etc)