### PR TITLE
feat(period): adapt to new getPeriodByBlockHeight API

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -219,9 +219,9 @@ export function getYoungestInputTx(plasma, tx) {
 export function getProof(plasma, tx, periodOpts = {}) {
   return plasma.getPeriodByBlockHeight(tx.blockNumber)
     .then(periodData => {
-      if (periodData && periodData.length) {
+      if (periodData) {
         Object.assign(periodOpts, {
-          validatorData: periodData[0],
+          validatorData: periodData,
         });
       } else {
         const msg = `No period data for the given tx. Height: ${tx.blockNumber}`;

--- a/lib/helpers.spec.js
+++ b/lib/helpers.spec.js
@@ -243,7 +243,7 @@ describe('helpers', () => {
         },
         getPeriodByBlockHeight: n => {
           expect(n).to.be.equal(4);
-          return Promise.resolve([{ slotId: 0, validatorAddress: ADDR_1, casBitmap }]);
+          return Promise.resolve({ slotId: 0, validatorAddress: ADDR_1, casBitmap });
         },
       };
 


### PR DESCRIPTION
Adapts to the changes introduced in https://github.com/leapdao/leap-node/pull/403/

getPeriodByBlockHeight API now returns _object_ instead of _array_.

This is BREAKING CHANGE