### PR TITLE
fix(period): wrong name for validator address attribute in period options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -257,7 +257,7 @@ declare module "leap-core" {
   type PeriodOptions = {
     validatorData?: {
       slotId: number;
-      ownerAddr: string | Buffer | number;
+      validatorAddress: string | Buffer | number;
       casBitmap?: string | Buffer | number; 
     };
     excludePrevHashFromProof?: Boolean;
@@ -340,7 +340,7 @@ declare module "leap-core" {
   };
 
   type PeriodData = {
-    ownerAddr: string;
+    validatorAddress: string;
     slotId: number;
     casBitmap?: string;
     periodStart?: number;

--- a/lib/helpers.spec.js
+++ b/lib/helpers.spec.js
@@ -203,7 +203,7 @@ describe('helpers', () => {
       };
 
       const periodOpts = {
-        validatorData: { slotId: 0, ownerAddr: ADDR_1 },
+        validatorData: { slotId: 0, validatorAddress: ADDR_1 },
         excludePrevHashFromProof: true,
       };
 
@@ -243,7 +243,7 @@ describe('helpers', () => {
         },
         getPeriodByBlockHeight: n => {
           expect(n).to.be.equal(4);
-          return Promise.resolve([{ slotId: 0, ownerAddr: ADDR_1, casBitmap }]);
+          return Promise.resolve([{ slotId: 0, validatorAddress: ADDR_1, casBitmap }]);
         },
       };
 

--- a/lib/period.js
+++ b/lib/period.js
@@ -26,7 +26,7 @@ export default class Period {
    * type PeriodOptions = {
    *   validatorData?: {
    *     slotId: number;
-   *     ownerAddr: string | Buffer | number;
+   *     validatorAddress: string | Buffer | number;
    *     casBitmap?: string | Buffer | number; 
    *   };
    *   excludePrevHashFromProof?: Boolean;

--- a/lib/period.js
+++ b/lib/period.js
@@ -44,10 +44,9 @@ export default class Period {
     if (blocks) {
       blocks.forEach(block => this.addBlock(block));
     }
-
-    const { slotId, ownerAddr, casBitmap } = opts.validatorData || {};
-    if ((slotId || slotId === 0) && ownerAddr) {
-      this.setValidatorData(slotId, ownerAddr, casBitmap);
+    const { slotId, validatorAddress, casBitmap } = opts.validatorData || {};
+    if ((slotId || slotId === 0) && validatorAddress) {
+      this.setValidatorData(slotId, validatorAddress, casBitmap);
     }
   }
 

--- a/lib/period.spec.js
+++ b/lib/period.spec.js
@@ -12,7 +12,7 @@ const slotId = 4;
 
 const validatorData = {
   slotId,
-  ownerAddr: ADDR
+  validatorAddress: ADDR
 };
 
 /**
@@ -88,7 +88,7 @@ describe('periods', () => {
     const period = new Period(null, [block1, block2], {
       validatorData: {
         slotId,
-        ownerAddr: ADDR,
+        validatorAddress: ADDR,
         casBitmap: '0x4000000000000000000000000000000000000000000000000000000000000000'
       },
       excludePrevHashFromProof: true


### PR DESCRIPTION
getPeriodByBlockHeight API returns `validatorAddress`, not `ownerAddress`:

```
curl --location --request POST 'https://testnet-node.leapdao.org/' \
--header 'Content-Type: application/json' \
--data-raw '{
  "method": "plasma_getPeriodByBlockHeight",
  "params": ["190000"],
  "id": 1,
  "jsonrpc": "2.0"
}'
```

returns

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        {
            "periodStart": 189984,
            "periodEnd": 190015,
            "casBitmap": "0xc000000000000000000000000000000000000000000000000000000000000000",
            "slotId": "0",
            "validatorAddress": "0xDe42468b9ba193384eA76e337BAe1676932133Cf"
        }
    ]
}
```